### PR TITLE
TOOLS-62 Add schedule to wf to run tests once per month

### DIFF
--- a/.github/workflows/run_tests_pr.yaml
+++ b/.github/workflows/run_tests_pr.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+  schedule:
+    - cron: "0 0 1 * *"
   
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Ticket ID
TOOLS-62

## Description
Added a schedule block to the workflow to run tests on the first day of each month
## Screenshots 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->